### PR TITLE
Added requirements-devel and enabled travis notifs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,21 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 notifications:
-  email: false
+  email: # sent to the committer and the author
+    on_success: never # default: always
+    on_failure: always # default: always
+
+  webhooks: # Gitter integration
+        urls:
+          - https://webhooks.gitter.im/e/f51458fa35835a48601a
+        # options: [always|never|change]
+        on_success: never    # default: always
+        on_failure: always   # default: always
+        on_start: never      # default: never
+
+        # not passing travis yaml validator, but specified in the doc
+        # on_cancel: never     # default: always
+        # on_error: always     # default: always
 
 sudo: false
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,3 +21,36 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+# Base bundle
+-e git+git://github.com/inveniosoftware/invenio-admin.git#egg=invenio-admin
+-e git+git://github.com/inveniosoftware/invenio-assets.git#egg=invenio-assets
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-celery.git#egg=invenio-celery
+-e git+git://github.com/inveniosoftware/invenio-config.git#egg=invenio-config
+-e git+git://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter
+-e git+git://github.com/inveniosoftware/invenio-i18n.git#egg=invenio-i18n
+-e git+git://github.com/inveniosoftware/invenio-logging.git#egg=invenio-logging
+-e git+git://github.com/inveniosoftware/invenio-mail.git#egg=invenio-mail
+-e git+git://github.com/inveniosoftware/invenio-rest.git#egg=invenio-rest
+-e git+git://github.com/inveniosoftware/invenio-theme.git#egg=invenio-theme
+# Auth bundle
+-e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
+-e git+git://github.com/inveniosoftware/invenio-accounts.git#egg=invenio-accounts
+-e git+git://github.com/inveniosoftware/invenio-oauth2server.git#egg=invenio-oauth2server
+-e git+git://github.com/inveniosoftware/invenio-oauthclient.git#egg=invenio-oauthclient
+-e git+git://github.com/inveniosoftware/invenio-userprofiles.git#egg=invenio-userprofiles
+# Metadata bundle
+-e git+git://github.com/inveniosoftware/invenio-indexer.git#egg=invenio-indexer
+-e git+git://github.com/inveniosoftware/invenio-jsonschemas.git#egg=invenio-jsonschemas
+-e git+git://github.com/inveniosoftware/invenio-oaiserver.git#egg=invenio-oaiserver
+-e git+git://github.com/inveniosoftware/invenio-pidstore.git#egg=invenio-pidstore
+-e git+git://github.com/inveniosoftware/invenio-records-rest.git#egg=invenio-records-rest
+-e git+git://github.com/inveniosoftware/invenio-records-ui.git#egg=invenio-records-ui
+-e git+git://github.com/inveniosoftware/invenio-records.git#egg=invenio-records
+-e git+git://github.com/inveniosoftware/invenio-search-ui.git#egg=invenio-search-ui
+-e git+git://github.com/inveniosoftware/invenio-search.git#egg=invenio-search
+# MARC21-based ILS
+-e git+git://github.com/inveniosoftware/invenio-app.git#egg=invenio-app
+-e git+git://github.com/inveniosoftware/invenio-marc21.git#egg=invenio-marc21
+


### PR DESCRIPTION
@lnielsen in the release PR we did not add new dependencies, so these ones should be the correct.
https://github.com/inveniosoftware/invenio-app-ils/pull/30/files

I have added email notifications only on_failure (we can always filter out those emails I guess) and the integration with Gitter.
Probably the only missing part is to activate a (cron? night/lunch/morning?) run of the devel build.

The optimal would be to trigger a build everything one module merges a PR in its master, but I guess this is much more complicated.